### PR TITLE
Manage TXT record max lenght of 255 chars

### DIFF
--- a/DNS/dnsData/dnsTXTresult.php
+++ b/DNS/dnsData/dnsTXTresult.php
@@ -8,8 +8,15 @@ namespace Metaregistrar\DNS {
         public function __construct($record)
         {
             parent::__construct();
-            $this->recordlength = ord($record[0]);
-            $this->setRecord(substr($record,1));
+            
+            $lenght = 0;
+            $txt = '';
+            foreach(str_split($record, 256) as $chunk) {
+                $lenght += ord($chunk[0]);
+                $txt .= substr($chunk,1);
+            }
+            $this->recordlength = $lenght;
+            $this->setRecord($txt);
         }
 
         public function setRecord($record)


### PR DESCRIPTION
TXT records have a maximum length of 255 characters, for TXT records that include more than 255 characters, DNS adds multiple strings together in a single record.

This is an example of a long record read with nslookup:
`nescafefrappe.com       text = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsEjHvg0w1cMwshjceHg/buMMudm4cXCkQ3Ae0clMIDu3lW2Ne7amWu3w+v8+FIeQbASclq04yP4krMzjK01G1U1zeR142T01PCBe4mU645vkq885QFQi8j4XGq0TRGh0c0VuPZRHfr6194f8w5SrpQ+PlF6aQcvCxaq1aLVJs0waS3ElrFvqn+LJ73u8mXgCD" "cECSDfqJhHgWin4VFnX867nGU7y7A9uM8v2fCzBltZNNYnSu8ofKmCJe8Tb7gaurWWteg5eE23Cx8w8hKARpmi9Urrhy0o4YT7rIIbQi/i52jfsdGqcPHKyvhozKrwWZrJAl+iXmwjVbaLYNLGt/QIDAQAB"`
where the long record is separated into multiple strings of up to 255 characters.

The library extracts the first character indicating the length of the string (see #12), but it does so only for the first portion of 255 characters, keeping the following ones.
`v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsEjHvg0w1cMwshjceHg/buMMudm4cXCkQ3Ae0clMIDu3lW2Ne7amWu3w+v8+FIeQbASclq04yP4krMzjK01G1U1zeR142T01PCBe4mU645vkq885QFQi8j4XGq0TRGh0c0VuPZRHfr6194f8w5SrpQ+PlF6aQcvCxaq1aLVJs0waS3ElrFvqn+LJ73u8mXgCD�cECSDfqJhHgWin4VFnX867nGU7y7A9uM8v2fCzBltZNNYnSu8ofKmCJe8Tb7gaurWWteg5eE23Cx8w8hKARpmi9Urrhy0o4YT7rIIbQi/i52jfsdGqcPHKyvhozKrwWZrJAl+iXmwjVbaLYNLGt/QIDAQAB`

This PR handles the result in chunks of 255 characters, solving the problem.